### PR TITLE
update meow keybinding

### DIFF
--- a/lisp/init-ai.el
+++ b/lisp/init-ai.el
@@ -75,11 +75,6 @@
     :models '(deepseek-chat deepseek-coder))
 
 
-  (gptel-make-anthropic "Claude"          ;Any name you want
-    :stream t                             ;Streaming responses
-    :key ai-anthropic-api-key
-    :models '(claude-3-5-sonnet-20241022 claude-3-7-sonnet-20250219))
-
   ;; Groq offers an OpenAI compatible API
   (setq gptel-model  'moonshotai/kimi-k2-instruct
         gptel-backend
@@ -88,39 +83,30 @@
           :endpoint "/openai/v1/chat/completions"
           :stream t
           :key groq-api-key
-          :models '(moonshotai/kimi-k2-instruct
-                    qwen-2.5-coder-32b
+          :models '(moonshotai/kimi-k2-instruct-0905
+                    moonshotai/kimi-k2-instruct
+                    qwen/qwen3-32b
                     deepseek-r1-distill-llama-70b
                     deepseek-r1-distill-qwen-32b
                     llama-3.3-70b-versatile))
         )
-
-  ;; (setq gptel-model 'claude-3-5-sonnet-20241022
-  ;;       gpt-backend (gptel-make-openai "MistralCode"  ;Any name you want
-  ;;                     :host "api.mistral.ai"
-  ;;                     :endpoint "/v1/chat/completions"
-  ;;                     :protocol "https"
-  ;;                     :key mistral-api-key               ;can be a function that returns the key
-  ;;                     :models '(codestral-latest mistral-large-latest))
-  ;;       )
   )
 
-(defconst relysium-directory
-  (expand-file-name "relysium"
-                    (file-name-directory (or load-file-name buffer-file-name)))
-  "Directory containing the relysium component files.")
-
-;; Add the directory to load path
-(add-to-list 'load-path relysium-directory)
-
-;; Load relysium after gptel is available
-(with-eval-after-load 'gptel
-  (require 'relysium)
-  (add-hook 'prog-mode-hook 'relysium-prog-mode))
-
-;; (use-package relysium
-;;   :elpaca (relysium :host github :repo "bluzky/relysium")
-;;   :hook (prog-mode . relysium-prog-mode))
+(use-package relysium
+  :elpaca (:host github :repo "bluzky/relysium")
+  :hook (prog-mode . relysium-prog-mode)
+  :commands (relysium-ask
+             relysium-edit-dwim
+             relysium-buffer-add-context
+             relysium-buffer-clear
+             relysium-debug-log
+             relysium-toggle-debug-mode
+             relysium-generate-from-comments
+             relysium-suggest
+             relysium-buffer-toggle-window)
+  :config
+  ;; Add any additional relysium configuration here
+  )
 
 
 (provide 'init-ai)

--- a/lisp/init-editor.el
+++ b/lisp/init-editor.el
@@ -5,6 +5,8 @@
   :config
   (xterm-mouse-mode 1)
   (setq initial-scratch-message "")
+  ;; enable system clipboard
+  (setq select-enable-clipboard t)
 
   ;; disable auto-save
   (auto-save-mode -1)
@@ -21,13 +23,6 @@
   (setq split-width-threshold 106)
   )
 
-
-;; enable system clipboard (built-in)
-(use-package emacs
-  :ensure nil
-  :config
-  (setq select-enable-clipboard t
-        select-enable-primary t))
 
 ;; Don’t bother confirming killing processes and don’t let backup~ files scatter around.
 (use-package files
@@ -82,20 +77,9 @@
             (lambda ()
               (add-hook 'prog-mode-hook #'electric-pair-mode))))
 
-;; Clean up whitespace on save
-(use-package whitespace
-  :ensure nil
-  :hook (before-save . whitespace-cleanup))
-
-
 ;; Syntax highlighting improvement
 (use-package highlight-numbers
   :defer t
-  :commands (highlight-numbers-mode)
-  :init
-  (add-hook 'after-init-hook
-            (lambda ()
-              (add-hook 'prog-mode-hook #'highlight-numbers-mode))))
-
+  :hook (prog-mode . highlight-numbers-mode))
 
 (provide 'init-editor)

--- a/lisp/init-git.el
+++ b/lisp/init-git.el
@@ -5,8 +5,7 @@
 (use-package magit
   :hook (with-editor-mode . meow-insert-mode)
   :bind (:map magit-status-mode-map
-              ("x" . magit-discard)
-              ("k" . nil))  ; Remove default k binding
+              ("x" . magit-discard))
   :config
   ;; sort branch by last commit date
   (setq magit-list-refs-sortby "-committerdate")

--- a/lisp/init-meow.el
+++ b/lisp/init-meow.el
@@ -11,6 +11,14 @@
   :config
   (meow-setup-indicator)
   
+  ;; Define custom replace function
+  (defun meow-replace-with-kill-ring ()
+    "Replace selection with head of kill-ring"
+    (interactive)
+    (when (region-active-p)
+      (delete-region (region-beginning) (region-end))
+      (yank)))
+  
   ;; Set magit modes to use insert state
   (add-to-list 'meow-mode-state-list '(magit-status-mode . insert))
   (add-to-list 'meow-mode-state-list '(magit-log-mode . insert))
@@ -109,7 +117,7 @@
    '("p" . meow-yank)
    '("P" . meow-yank-pop)
    '("q" . meow-quit)
-   '("Q" . meow-goto-line)
+   '(":" . meow-goto-line)
    '("r" . meow-replace)
    '("R" . meow-swap-grab)
    '("s" . meow-kill)
@@ -132,11 +140,25 @@
    '("\"" . meow-comment)
    '("%" . meow-query-replace)
    '("&" . meow-query-replace-regexp)
+   '("{" . backward-paragraph)
+   '("}" . forward-paragraph)
    '("<escape>" . ignore))
 
   (global-set-key (kbd "C-u") #'kill-whole-line)
-  ;; Configure escape key to exit insert mode
-  (define-key meow-insert-state-keymap [escape] 'meow-insert-exit)
+  
+  ;; Separate C-i from Tab and C-[ from ESC
+  (define-key input-decode-map (kbd "C-i") (kbd "H-i"))
+  (define-key input-decode-map (kbd "C-[") (kbd "H-["))
+  
+  ;; Configure jump list navigation for both normal and insert states
+  (define-key meow-normal-state-keymap (kbd "C-o") 'meow-pop-to-mark)
+  (define-key meow-normal-state-keymap (kbd "H-i") 'meow-unpop-to-mark)
+  (define-key meow-insert-state-keymap (kbd "C-o") 'meow-pop-to-mark)
+  (define-key meow-insert-state-keymap (kbd "H-i") 'meow-unpop-to-mark)
+  
+  ;; Configure H-[ (C-[) to exit insert mode
+  (define-key meow-insert-state-keymap (kbd "H-[") 'meow-insert-exit)
+  
   ;; Enable meow-mode
   (meow-global-mode 1)
 

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -62,11 +62,6 @@
   (eglot-booster-mode))
 
 
-;; code folding
-(use-package origami
-  :hook (prog-mode . origami-mode))
-
-;;
 (use-package citre
   :defer t
   :init

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -1,4 +1,3 @@
-
 ;; Modernize selection behavior
 ;; Replace the active region just by typing text, just like modern editors.
 (use-package delsel
@@ -36,16 +35,12 @@
   (setq initial-frame-alist '((fullscreen . maximized)))
   (ian/set-default-font))
 
-;; custom theme
-(add-to-list 'custom-theme-load-path (concat user-emacs-directory "themes/"))
-
-
 ;; Or if you have use-package installed
 (use-package ef-themes
   :ensure t
   :config
   (load-theme 'ef-day t)
-  
+
   ;; auto dark theme
   (defun me/apply-theme (appearance)
     "Load theme, taking current system APPEARANCE into consideration."

--- a/lisp/init-whichkey.el
+++ b/lisp/init-whichkey.el
@@ -132,8 +132,8 @@
   (define-key my-leader-map (kbd "i y") 'consult-yasnippet)
 
   ;; Search operations
-  (define-key my-leader-map (kbd "s s") 'swiper)
-  (define-key my-leader-map (kbd "s S") 'swiper-thing-at-point)
+  (define-key my-leader-map (kbd "s s") 'consult-line)
+  (define-key my-leader-map (kbd "s S") 'me/consult-line-thing-at-point)
   (define-key my-leader-map (kbd "s p") 'consult-ripgrep)
   (define-key my-leader-map (kbd "s P") 'me/search-project)
   (define-key my-leader-map (kbd "s f") 'me/search-dir)


### PR DESCRIPTION
## Summary by Sourcery

Refresh Emacs configuration across multiple modules by streamlining AI setup, refining Meow keybindings, simplifying editor and UI settings, replacing swiper with consult, and pruning deprecated packages and bindings.

New Features:
- Add meow-replace-with-kill-ring command to replace selection with the kill-ring head

Enhancements:
- Simplify init-ai by removing obsolete Anthropic blocks, updating Groq model list, and consolidating relysium into a use-package declaration
- Refine Meow keybindings: rebind goto-line to ':', add paragraph navigation, separate C-i/C-[ decoding, and configure jump list navigation with C-o, H-i, and H-[
- Enable system clipboard and streamline whitespace cleanup and highlight-numbers hooks in init-editor
- Remove custom theme load path and clean up leading whitespace in init-ui
- Swap swiper bindings for consult-line and custom line-at-point in init-whichkey
- Clean up magit-status-mode bindings to only keep magit-discard

Chores:
- Drop origami code folding in init-prog
- Remove redundant configuration blocks for clipboard, whitespace, and theme loading